### PR TITLE
feat/better-input-handling

### DIFF
--- a/chat-client/src/client.ts
+++ b/chat-client/src/client.ts
@@ -1,10 +1,10 @@
-
 import WebSocket from "ws";
 import readline from "readline";
 
 const rl = readline.createInterface({
     input: process.stdin,
     output: process.stdout,
+    prompt: "> ",
 });
 
 const ws = new WebSocket("ws://localhost:8080");
@@ -65,7 +65,7 @@ function handleServerMessage(message: any) {
             });
             break;
         case "message":
-            console.log(`${message.payload.sender}: ${message.payload.message}`);
+            console.log(`${message.payload.message}`);
             break;
         case "error":
             console.error(`Error: ${message.payload}`);
@@ -74,12 +74,21 @@ function handleServerMessage(message: any) {
 }
 
 function startChat() {
+    rl.prompt();
+
     rl.on("line", (line) => {
+
+        if (!line.trim()) return;
+
         ws.send(
             JSON.stringify({
                 type: "message",
                 payload: { roomId, sender: username, message: line },
             })
         );
+
+        process.stdout.moveCursor(0, -1);
+        process.stdout.clearLine(1);
+        rl.prompt(true);
     });
 }

--- a/chat-server/src/server.ts
+++ b/chat-server/src/server.ts
@@ -1,4 +1,3 @@
-
 import { WebSocketServer, WebSocket } from "ws";
 import crypto from "crypto";
 
@@ -134,7 +133,7 @@ function broadcastMessage(roomId: string, sender: string, message: string) {
     const room = chatRooms[roomId];
     if (!room) return;
 
-    const formattedMessage = `[${new Date().toISOString()}] ${sender}: ${message}`;
+    const formattedMessage = ` ${sender}: ${message}`;
     room.messageHistory.push(formattedMessage);
 
     if (room.messageHistory.length > messsge_history_limit) {
@@ -149,7 +148,6 @@ function broadcastMessage(roomId: string, sender: string, message: string) {
         );
     });
 
-    console.log(`[Room ${roomId}] ${formattedMessage}`);
 }
 
 function handleDisconnection(ws: WebSocket) {


### PR DESCRIPTION
Up till now, whenever a user sent a message it would appear twice on their screen. Once as the input text that they typed and second as the formatted message broadcasted to every client. This would only happen on the senders screen, and now I have fixed it using the readline clearLine() function.